### PR TITLE
Allow un-selecting non-required select fields.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     compile 'org.joda:joda-convert:1.8.1'
     compile 'com.google.code.findbugs:jsr305:3.0.1'
     // form builder
-    compile 'com.github.azavea:AndroidValidatedForms:1.1.9'
+    compile 'com.github.azavea:AndroidValidatedForms:1.1.10'
     // Android libraries
     compile 'com.android.support:appcompat-v7:23.2.0'
     compile 'com.android.support:recyclerview-v7:23.2.0'

--- a/app/src/main/java/org/worldbank/transport/driver/activities/RecordFormActivity.java
+++ b/app/src/main/java/org/worldbank/transport/driver/activities/RecordFormActivity.java
@@ -300,8 +300,11 @@ public abstract class RecordFormActivity extends FormWithAppCompatActivity {
                             }
                         } else {
                             SelectListInfo enumListInfo = buildSelectEnumInfo(enumClass);
-                            // TODO: fix or remove prompt arg in form builder library
-                            // no matter what gets passed for the prompt argument, it seems to always display "Select"
+                            if (!isRequired) {
+                                Log.d(LOG_LABEL, "Adding empty option to list for " + fieldClass);
+                                enumListInfo.labels.add(0, "");
+                                enumListInfo.items.add(0, "");
+                            }
                             control = new SelectionController(this, fieldName, fieldLabel, isRequired, "Select",
                                     enumListInfo.labels, enumListInfo.items);
                         }
@@ -326,7 +329,7 @@ public abstract class RecordFormActivity extends FormWithAppCompatActivity {
                 }
             } else {
                 if (constantFieldType == null) {
-                    // TODO: in this case, it's probably a subsection. Does that ever happen?
+                    // In this case, it's probably a subsection, which doesn't happen in our usage.
                     Log.e(LOG_LABEL, "No field type found for field " + fieldName);
                     continue;
                 } else {


### PR DESCRIPTION
Empty string in non-required select field will now set model to null in form builder library.
Select field needs an object with `toString` and `equals` method, so using an empty string is convenient for that purpose.
