### PR TITLE
WIP: Update travis target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+dist: precise
 
 sudo: required
 addons:
@@ -22,20 +23,20 @@ android:
     - extra-google-m2repository
     - extra-android-support
     - android-24
-    - sys-img-armeabi-v7a-android-25
-    - addon-google_apis-google-25
+    - sys-img-armeabi-v7a-android-17
+    - addon-google_apis-google-17
     - build-tools-24.0.2
 
 before_install:
   - free -m # show available memory on VM
   - cp templates/configurables.xml.template app/src/main/res/values/configurables.xml
-  - ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui -a --filter android-24,tools,platform-tools,addon-google_apis-google-25,extra-android-m2repository,extra-google-m2repository,extra-android-support --force > /dev/null
+  - ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui -a --filter android-24,tools,platform-tools,addon-google_apis-google-17,extra-android-m2repository,extra-google-m2repository,extra-android-support --force > /dev/null
   - ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui -a --filter "build-tools-24.0.2" --force > /dev/null
 
 before_script:
   - ulimit -c unlimited -S # increase stack size
   - android list targets # to debug
-  - echo no | android create avd --force -n test -t "Google Inc.:Google APIs:25" --abi armeabi-v7a --skin HVGA
+  - echo no | android create avd --force -n test -t "Google Inc.:Google APIs:17" --abi armeabi-v7a --skin HVGA
   - sleep 5
   - emulator -avd test -no-skin -no-audio -no-window -no-boot-anim -dpi-device 480 &
   - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,20 +22,20 @@ android:
     - extra-google-m2repository
     - extra-android-support
     - android-24
-    - sys-img-armeabi-v7a-android-17
-    - addon-google_apis-google-17
+    - sys-img-armeabi-v7a-android-25
+    - addon-google_apis-google-25
     - build-tools-24.0.2
 
 before_install:
   - free -m # show available memory on VM
   - cp templates/configurables.xml.template app/src/main/res/values/configurables.xml
-  - ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui -a --filter android-24,tools,platform-tools,addon-google_apis-google-17,extra-android-m2repository,extra-google-m2repository,extra-android-support --force > /dev/null
+  - ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui -a --filter android-24,tools,platform-tools,addon-google_apis-google-25,extra-android-m2repository,extra-google-m2repository,extra-android-support --force > /dev/null
   - ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui -a --filter "build-tools-24.0.2" --force > /dev/null
 
 before_script:
   - ulimit -c unlimited -S # increase stack size
   - android list targets # to debug
-  - echo no | android create avd --force -n test -t "Google Inc.:Google APIs:17" --abi armeabi-v7a --skin HVGA
+  - echo no | android create avd --force -n test -t "Google Inc.:Google APIs:25" --abi armeabi-v7a --skin HVGA
   - sleep 5
   - emulator -avd test -no-skin -no-audio -no-window -no-boot-anim -dpi-device 480 &
   - sleep 10


### PR DESCRIPTION
Switch to `precise` for running Travis build, to regain access to old Android images.