### PR TITLE
Move instance configuration parameters out of source

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ cp templates/configurables.xml.template app/src/main/res/values/configurables.xm
 ```
 
 - Set the URL for your DRIVER API server in `configurables.xml` under `api_server_url`.
-- Set the "signing\_cert\_pem\_url" to be the URL to the keystore certificate file (if building for
+- Set the `signing_cert_pem_url` to be the URL to the keystore certificate file (if building for
   an existing stack, this should already be available; if building for a new stack, you will need to
   upload the certificate file somewhere)
+- Set `record_type_label` to be the label for the default record type (eg. "Incident"). NOTE: you can see all record types by going to `https://{your-driver-domain}/api/recordtypes/`.
 - If you want to support Google Sign-In, follow the instructions below to set it up, and then fill
-  in the "oauth\_client\_id".
+  in the `oauth_client_id`.
 
 ```
 cp templates/release.properties.template app/release.properties
@@ -72,7 +73,7 @@ file must be signed with the release key. To generate this file, select the sche
 use as your initial class definition, and then access
 `https://{your-driver-domain}/api/jars/{schema-uuid}/`. You will receive a 201 response. Wait about a
 minute and then reload, passing in the query parameter `format=jar` to download the jar file (eg. `https://{your-driver-domain}/api/jars/{schema-uuid}/?format=jar`). You should receive a jar file that you can use for models.jar. If you
-update models.jar, also update the UUID `BACKUP_JAR_SCHEMA_VERSION` in `DriverApp`.
+update models.jar, also update the UUID in `backup_jar_schema_version` in `configurables.xml`.
 
 ## Building for Release
 To build a signed version of the app that will reload model files when there is a schema update:

--- a/app/src/main/java/org/worldbank/transport/driver/staticmodels/DriverApp.java
+++ b/app/src/main/java/org/worldbank/transport/driver/staticmodels/DriverApp.java
@@ -54,7 +54,6 @@ public class DriverApp extends Application {
     private static String SCHEMA_CERT_URL;
 
     public static final String BACKUP_JAR_NAME = "models.jar";
-    public static final String BACKUP_JAR_SCHEMA_VERSION = "b9f5c292-7393-4f15-b298-7d1cf9c9a942";
     public static final String UPDATED_JAR_NAME = "updatedModels.jar";
 
     /**
@@ -318,7 +317,7 @@ public class DriverApp extends Application {
      * Helper to revert to the backup model classes, if updates not found or could not be loaded.
      */
     public void loadBackupSchema() {
-        if (loadSchemaClasses(BACKUP_JAR_NAME, BACKUP_JAR_SCHEMA_VERSION)) {
+        if (loadSchemaClasses(BACKUP_JAR_NAME, getString(R.string.backup_jar_schema_version))) {
             Log.d(LOG_LABEL, "Reverted to backup schema");
         } else {
             Log.e(LOG_LABEL, "Could not load backup schema!");

--- a/app/src/main/java/org/worldbank/transport/driver/tasks/CheckSchemaTask.java
+++ b/app/src/main/java/org/worldbank/transport/driver/tasks/CheckSchemaTask.java
@@ -29,9 +29,6 @@ import java.util.UUID;
  */
 public class CheckSchemaTask extends AsyncTask<DriverUserInfo, String, String> {
 
-    /* The name of the record type in use by the app; should match default in web app */
-    private static final String RECORD_TYPE_LABEL = "Incident";
-
     private static final String LOG_LABEL = "CheckSchemaTask";
 
     public interface CheckSchemaCallbackListener {
@@ -100,7 +97,9 @@ public class CheckSchemaTask extends AsyncTask<DriverUserInfo, String, String> {
         }
 
         try {
-            URL url = currentSchemaUrl.currentSchemaUrl(serverUrl, RECORD_TYPE_LABEL);
+            // The name of the record type in use by the app; should match default in web app
+            String recordTypeLabel = context.getString(R.string.record_type_label);
+            URL url = currentSchemaUrl.currentSchemaUrl(serverUrl, recordTypeLabel);
 
             HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
             urlConnection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");

--- a/app/src/main/java/org/worldbank/transport/driver/tasks/UpdateSchemaTask.java
+++ b/app/src/main/java/org/worldbank/transport/driver/tasks/UpdateSchemaTask.java
@@ -184,7 +184,7 @@ public class UpdateSchemaTask extends AsyncTask<String, String, String> {
 
                     // load backup model jar file
                     driverApp.loadBackupSchema();
-                    return DriverApp.BACKUP_JAR_SCHEMA_VERSION;
+                    return context.getString(R.string.backup_jar_schema_version);
                 }
 
             } else {

--- a/templates/configurables.xml.template
+++ b/templates/configurables.xml.template
@@ -2,6 +2,9 @@
 <resources>
     <string name="api_server_url" translatable="false">https://example.com</string>
     <string name="signing_cert_pem_url" translatable="false">https://worldbank-transport.github.io/DRIVER-Android/sa/driver_android_certificate.pem</string>
+    <!-- should be localized string for default record type label -->
+    <string name="record_type_label" translatable="false">Incident</string>
+    <string name="backup_jar_schema_version" translatable="false"></string>
     <string name="oauth_client_id" translatable="false"></string>
     <!-- debug setting for testing the calendar formatting -->
     <bool name="always_use_sa_locale" translatable="false">false</bool>


### PR DESCRIPTION
# Overview

Move instance configuration parameters out of source.

This should make it easier to configure an instance properly since it
will be clearer what needs to be configured (and harder to forget to set
the necessary parameters).

# Notes

There is a bug with updating the schema for the recently set up Laos Android app which was caused by forgetting to set the record type label to the localized string of "ການແຊກແຊງ".

# Testing Instructions

I don't think this needs to be tested since it's such a trivial change. However, I have verified that it compiles. 